### PR TITLE
AttributeNames req param

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -57,7 +57,7 @@ func Start(svc *sqs.SQS, h Handler) {
 		params := &sqs.ReceiveMessageInput{
 			QueueUrl:            aws.String(QueueURL), // Required
 			MaxNumberOfMessages: aws.Int64(MaxNumberOfMessage),
-			MessageAttributeNames: []*string{
+			AttributeNames: []*string{
 				aws.String("All"), // Required
 			},
 			WaitTimeSeconds: aws.Int64(WaitTimeSecond),


### PR DESCRIPTION
MessageAttributeNames req param doesnt return anything, needs to be AttributeName(s)

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html