### PR TITLE
Dynamically set MaximumNumberOfMessages

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -52,7 +52,7 @@ var (
 )
 
 // Start starts the polling and will continue polling till the application is forcibly stopped
-func Start(ctx context.Context, svc *sqs.SQS, h Handler) {
+func Start(ctx context.Context, maxNumberOfMessages int64, svc *sqs.SQS, h Handler) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -62,13 +62,13 @@ func Start(ctx context.Context, svc *sqs.SQS, h Handler) {
 			Log.Debug("worker: Start Polling")
 			params := &sqs.ReceiveMessageInput{
 				QueueUrl:            aws.String(QueueURL), // Required
-				MaxNumberOfMessages: aws.Int64(MaxNumberOfMessage),
+				MaxNumberOfMessages: aws.Int64(maxNumberOfMessages),
 				AttributeNames: []*string{
 					aws.String("All"), // Required
 				},
 				WaitTimeSeconds: aws.Int64(WaitTimeSecond),
 			}
-      
+
 			resp, err := svc.ReceiveMessage(params)
 			if err != nil {
 				log.Println(err)


### PR DESCRIPTION
Instead of having a fixed number of Maximum SQS Messages to be parsed in Parallel, this Pull Request will add a parameter to the `Start` function which would enable the user to specify how many Messages they wish to process in parallel.

This is also suitable for users who wish to process messages sequentially: by specifying the maximum number of messages to 1, it will maintain the code structure, which uses go routines, all the while providing a sequential-like execution