### PR TITLE
Reduce MaxNumberOfMessage to 10

### DIFF
--- a/cmd/example-worker/main.go
+++ b/cmd/example-worker/main.go
@@ -19,7 +19,7 @@ func main() {
 	sqsClient := worker.CreateSqsClient(awsConfig)
 	workerConfig := &worker.Config{
 		QueueName:          "my-sqs-queue",
-		MaxNumberOfMessage: 15,
+		MaxNumberOfMessage: 10,
 		WaitTimeSecond:     5,
 	}
 	eventWorker := worker.New(sqsClient, workerConfig)


### PR DESCRIPTION
This PR only reduces the current number to 10 (the current maximum), since the initial value 15 raises an exception at runtime. Thanks for sharing the project, it has been very useful to me! 

```
2020/09/11 15:38:13 InvalidParameterValue: Value 15 for parameter MaxNumberOfMessages is invalid. Reason: Must be between 1 and 10, if provided.
	status code: 400
```