### PR TITLE
QueueAPI interface defines the minimum interface.

### DIFF
--- a/worker/util.go
+++ b/worker/util.go
@@ -26,7 +26,7 @@ func (config *Config) populateDefaultValues() {
 	}
 }
 
-func getQueueURL(client sqsiface.SQSAPI, queueName string) (queueURL string) {
+func getQueueURL(client QueueAPI, queueName string) (queueURL string) {
 	params := &sqs.GetQueueUrlInput{
 		QueueName: aws.String(queueName), // Required
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 )
 
 // HandlerFunc is used to define the Handler that is run on for each message
@@ -39,11 +38,18 @@ func NewInvalidEventError(event, msg string) InvalidEventError {
 	return InvalidEventError{event: event, msg: msg}
 }
 
+// QueueAPI interface is the minimum interface required from a queue implementation
+type QueueAPI interface {
+	DeleteMessage(*sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error)
+	GetQueueUrl(*sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error)
+	ReceiveMessage(*sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error)
+}
+
 // Worker struct
 type Worker struct {
 	Config    *Config
 	Log       LoggerIFace
-	SqsClient sqsiface.SQSAPI
+	SqsClient QueueAPI
 }
 
 // Config struct
@@ -55,7 +61,7 @@ type Config struct {
 }
 
 // New sets up a new Worker
-func New(client sqsiface.SQSAPI, config *Config) *Worker {
+func New(client QueueAPI, config *Config) *Worker {
 	config.populateDefaultValues()
 	config.QueueURL = getQueueURL(client, config.QueueName)
 

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -17,7 +16,7 @@ import (
 type mockedSqsClient struct {
 	Config   *aws.Config
 	Response sqs.ReceiveMessageOutput
-	sqsiface.SQSAPI
+	QueueAPI
 	mock.Mock
 }
 


### PR DESCRIPTION
It is the minimum interface that Worker requires from a queue implementation.