### PR TITLE
feat(worker): add messageAttributeNames to SQS input

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -95,6 +95,9 @@ func (worker *Worker) Start(ctx context.Context, h Handler) {
 				AttributeNames: []*string{
 					aws.String("All"), // Required
 				},
+				MessageAttributeNames: []*string{
+					aws.String(sqs.QueueAttributeNameAll),
+				},
 				WaitTimeSeconds: aws.Int64(worker.Config.WaitTimeSecond),
 			}
 

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -127,9 +127,10 @@ func buildClientParams() *sqs.ReceiveMessageInput {
 	url := aws.String("https://sqs.eu-west-1.amazonaws.com/123456789/my-sqs-queue")
 
 	return &sqs.ReceiveMessageInput{
-		QueueUrl:            url,
-		MaxNumberOfMessages: aws.Int64(maxNumberOfMessages),
-		AttributeNames:      []*string{aws.String("All")},
-		WaitTimeSeconds:     aws.Int64(waitTimeSecond),
+		QueueUrl:              url,
+		MaxNumberOfMessages:   aws.Int64(maxNumberOfMessages),
+		AttributeNames:        []*string{aws.String("All")},
+		MessageAttributeNames: []*string{aws.String(sqs.QueueAttributeNameAll)},
+		WaitTimeSeconds:       aws.Int64(waitTimeSecond),
 	}
 }


### PR DESCRIPTION
ask SQS to return all of the message attribute names so that they become available in the response

fix #15